### PR TITLE
Handle json with key/value has double backslash

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,16 @@ function fastJSON(input, path) {
           if (ch === '"' && input[j - 1] !== '\\') { // Make sure " doesn't escaped.
             break
           }
+           else if (ch == '"' && input[j - 1] === '\\') { // handle case with \\",\\\\"
+            let backslashCount = 1;
+            while (input[j - 1 - backslashCount] === '\\') {
+              backslashCount++;
+            }
+
+            if (backslashCount % 2 === 0) {
+              break;
+            }
+          }
         }
 
         // Check if current key is what we was looking for.

--- a/test.js
+++ b/test.js
@@ -105,6 +105,58 @@ test(t => {
   t.is(get(json, 'about'), json.about)
 })
 
+test(t=>{
+  const json = {foo: "\\"}
+  t.deepEqual(get(json, 'foo'), json.foo)
+})
+
+test(t=>{
+  const json = {foo: "\\\\"}
+  t.deepEqual(get(json, 'foo'), json.foo)
+})
+
+test(t=>{
+  const json = {foo: "\\\\\\"}
+  t.deepEqual(get(json, 'foo'), json.foo)
+})
+
+test(t=>{
+  const json = {foo: "\\b"}
+  t.deepEqual(get(json, 'foo'), json.foo)
+})
+
+test(t=>{
+  const json = {foo: "b\\"}
+  t.deepEqual(get(json, 'foo'), json.foo)
+})
+
+test(t=>{
+  const json = {foo: "b\\"}
+  t.deepEqual(get(json, 'foo'), json.foo)
+})
+
+test(t=>{
+  const r = fastJSON('{"foo-1": "bar"}', ['foo-1'])
+  t.is(r, 'bar')
+})
+
+test(t=>{
+  const r = fastJSON('{"foo\\"": "bar"}', ['foo\\"']) /**This is wrong lookup, it should be foo" only, may need to fix later */
+  t.is(r, 'bar')
+})
+
+test(t=>{
+  const r = fastJSON('{"foo\\\\": "bar"}', ['foo\\\\']) /**This is wrong lookup, it should be foo\\ only, may need to fix later */
+  t.is(r, 'bar')
+})
+
+test(t=>{
+  const r = fastJSON('{"\\\\": "bar"}', ['\\\\']) /**This is wrong lookup, it should be \\ only, may need to fix later */
+  t.is(r, 'bar')
+})
+
+
+
 function data() {
   return {
     "_id": "5b9cc0c64c0c3df825daf917",


### PR DESCRIPTION
If json has field/value has double backslash+quote (i.e {key:"b\\"}), it will throw exception. This pr will fix this problem.